### PR TITLE
Swap wallis filter use of scipy.ndimage.euclidean_distance_transform for cv2.distanceTransform

### DIFF
--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -69,9 +69,9 @@ def _wallis_filter_fill(image, filter_width, std_cutoff):
 
     # find edges of image, this makes missing scan lines valid and will
     # later be filled with random white noise
-    potential_data = distance_transform_edt(image.mask) < 30
+    potential_data = cv2.distanceTransform(image.mask.astype(np.uint8), distanceType=cv2.DIST_L2, maskSize=cv2.DIST_MASK_PRECISE) < 30
     missing_data = potential_data & image.mask
-    missing_data = distance_transform_edt(~missing_data) <= buff
+    missing_data = cv2.distanceTransform((~missing_data).astype(np.uint8), distanceType=cv2.DIST_L2, maskSize=cv2.DIST_MASK_PRECISE) <= buff
 
     # trying to frame out the image
     valid_domain = ~image.mask | missing_data
@@ -84,7 +84,7 @@ def _wallis_filter_fill(image, filter_width, std_cutoff):
     std = _preprocess_filt_std(image, kernel)
 
     low_std = std < std_cutoff
-    low_std = distance_transform_edt(~low_std) <= buff
+    low_std = cv2.distanceTransform((~low_std).astype(np.uint8), distanceType=cv2.DIST_L2, maskSize=cv2.DIST_MASK_PRECISE) <= buff
     missing_data = (missing_data | low_std) & valid_domain
 
     image = shifted / std


### PR DESCRIPTION
Not sure if this was the best place to put this PR, but the changes are simple and can be easy moved. Can confirm that AutoRIFT runs successfully after these changes were made.

For comparison sake here are some numpy data dumps:
[input mask file](https://ffwilliams2-shenanigans.s3.us-west-2.amazonaws.com/edt/not_missing.npy)
[scipy edt](https://ffwilliams2-shenanigans.s3.us-west-2.amazonaws.com/edt/ndimage_edt.npy)
[cv2 edt](https://ffwilliams2-shenanigans.s3.us-west-2.amazonaws.com/edt/cv2_edt.npy)

[offset.tif](https://ffwilliams2-shenanigans.s3.us-west-2.amazonaws.com/edt/ndimage_offset.tif) produced using scipy edt
[offset.tif](https://ffwilliams2-shenanigans.s3.us-west-2.amazonaws.com/edt/cv2_offset.tif) produced using cv2 edt
hyp3_autorift command used: `hyp3_autorift --username ${EDL_USERNAME} --password ${EDL_PASSWORD} LE07_L1TP_061018_20040321_20200915_02_T1 LE07_L1TP_062018_20040225_20200915_02_T1`